### PR TITLE
e2e tests passing added callback to request

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,18 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "E2E Test Debug",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "start",
+                "test.e2e"
+            ],
+            "timeout": 60000
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "Debug",
             "program": "${workspaceRoot}/dist/main.js",
             "smartStep": true,

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -23,13 +23,14 @@ describe('Users', () => {
         await app.init();
     });
 
-    it(`/GET user`, () => {
-        return request(app.getHttpServer())
+    it(`/GET user`, (done) => {
+        request(app.getHttpServer())
             .get('user')
             .expect(200)
             .expect({
                 data: userService.getUser(),
-            });
+            })
+            .end(() => done());
     });
 
     afterAll(async () => {


### PR DESCRIPTION
In the `user.e2e-spec.ts` file on your test I added done to the test function as a callback, then after the supertest request ended, I called `.end(() => done());` to signify to jest that everything has completed. I'm still not sure why you initially got a ECONNREFUSED for port 80, but at least now the test passes. Still is strange though.